### PR TITLE
Implement telemetry system for operational insights and enhance logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,12 @@ jobs:
         run: cargo install rojo --version 7.7.0-rc.1
 
       - name: Install dependencies
-        run: npm i 
+        run: npm i
 
-      - name: Compile Roblox Ts 
+      - name: Stamp release version
+        run: echo "export const CENTRE_VERSION = \"${{ github.event.release.tag_name }}\";" > src/version.ts
+
+      - name: Compile Roblox Ts
         run: npm run compile
       
       - name: Build  

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@ moduleInstance.Parent = ReplicatedStorage
 local RankgunModule = require(moduleInstance)
 RankgunModule.Init({
     workspaceId = "<workspace-id>",
-    apiToken = "<api-token>"
+    apiToken = "<api-token>",
+    -- verbose = true, -- optional; logs API requests/responses to the server console for debugging
 })
 ```
 
@@ -31,6 +32,22 @@ RankgunModule.Init({
 > As a RankGun customer, use the loader scripts available for download in your [Workspace](https://www.rankgun.works/workspace/), which will pre-fill the necessary details and automatically update.
 
 Before using, you must enable a few Experience Settings - namely, Security -> Allow HTTP Requests and Allow Loading Third Party Assets. You may also wish to enable DataStores in Studio to allow for playtesting.
+
+## Telemetry
+
+So that RankGun can support self-hosted centres, the centre reports lightweight, aggregate
+operational telemetry to RankGun's API (`/api/telemetry`) using the same API key it already
+uses for ranking. This lets RankGun see whether a centre is online, what build it's running,
+how rank redemptions are converting, and where API calls are failing.
+
+It sends only instance-level facts (centre version, place/universe/server id, environment,
+current player count, uptime) and a small set of events: `centre_boot`, `heartbeat`,
+`ranks_loaded`, `rank_redeem_attempt`, `gamepass_not_owned`, `rank_result`, and `api_error`
+(HTTP status + short error code only).
+
+**No end-user data is ever collected** — no UserIds, usernames, or raw error bodies. All
+requests are best-effort and run on a background thread, so telemetry never affects gameplay.
+See `src/server/telemetry.ts`.
 
 ## Development
 

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,7 +1,7 @@
 import "@rbxts-js/react";
 import React, { StrictMode } from "@rbxts/react";
 import { createPortal, createRoot } from "@rbxts/react-roblox";
-import { Players, StarterGui } from "@rbxts/services";
+import { Players, StarterGui, LogService } from "@rbxts/services";
 import BannerNotify from "@rbxts/banner-notify";
 
 import Layout from "./components/Layout";
@@ -38,7 +38,7 @@ function DisableGui() {
 }
 
 export function Init() {
-    print("[Rankgun] Initialising client UI");
+    LogService.Info("[Rankgun] Initialising client UI");
 
     const portal = createPortal(<CentreGui />, playerGui);
     root.render(<StrictMode>{portal}</StrictMode>);

--- a/src/server/clientLoader.client.ts
+++ b/src/server/clientLoader.client.ts
@@ -1,8 +1,9 @@
 const ReplicatedStorage = game.GetService("ReplicatedStorage");
+const LogService = game.GetService("LogService");
 const RankgunInstance = ReplicatedStorage.WaitForChild("rankgun-ranking-centre", 5) as ModuleScript;
 
 if (!RankgunInstance) {
-    warn("[Rankgun] Could not load client scripts");
+    LogService.Warn("[Rankgun] Could not load client scripts");
 } else {
     const Rankgun = require(RankgunInstance) as { Init: () => void };
     Rankgun.Init();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,10 +1,11 @@
-import { MarketplaceService, Players } from "@rbxts/services";
+import { MarketplaceService, Players, LogService } from "@rbxts/services";
 import BannerNotify from "@rbxts/banner-notify";
 
 import { remotes } from "shared/remotes";
-import { Rank } from "shared/types";
+import { Rank, RankgunInitConfig } from "shared/types";
 
-import { getRanks, setRank } from "./rankgunApi";
+import { getRanks, setRank, setVerbose } from "./rankgunApi";
+import { Telemetry } from "./telemetry";
 
 function notifyError(player: Player, header: string, message: string) {
     BannerNotify.Notify({
@@ -27,14 +28,25 @@ function redeemRank(player: Player, rankId: number, workspaceId: string, apiToke
             return;
         }
 
+        Telemetry.track("rank_redeem_attempt", { targetRankId: rankId });
+
         if (MarketplaceService.UserOwnsGamePassAsync(player.UserId, rank.gamepassId) === false) {
+            Telemetry.track("gamepass_not_owned", { targetRankId: rankId });
             notifyError(player, "Gamepass not owned", "You don't yet own the required gamepass for this rank.");
         } else {
             try {
                 const rankResponse = setRank(player, rankId, workspaceId, apiToken);
-                if (!rankResponse || rankResponse.StatusCode !== 200) {
-                    warn(`[Rankgun] Failed to set rank:`);
-                    warn(rankResponse);
+                const ranked = rankResponse !== undefined && rankResponse.StatusCode === 200;
+
+                Telemetry.track("rank_result", {
+                    targetRankId: rankId,
+                    success: ranked,
+                    httpStatus: rankResponse ? rankResponse.StatusCode : undefined,
+                });
+
+                if (!ranked) {
+                    LogService.Warn("[Rankgun] Failed to set rank");
+                    if (rankResponse && rankResponse.Body) LogService.Warn("[Rankgun] Response Body", rankResponse.Body);
 
                     notifyError(player, "Failed to set rank", "We couldn't rank you due to an error. Try again.");
                 } else {
@@ -47,13 +59,13 @@ function redeemRank(player: Player, rankId: number, workspaceId: string, apiToke
                     });
                 }
             } catch (err) {
-                warn(`[Rankgun] Error while ranking user:`)
-                warn(err);
+                Telemetry.track("rank_result", { targetRankId: rankId, success: false });
+                LogService.Warn(`[Rankgun] Error while ranking user: ${tostring(err)}`);
                 notifyError(player, "Internal server error", "We couldn't rank you due to an error. Try again.");
             }
         }
     } else {
-        warn(`[Rankgun] Could not load passes`)
+        LogService.Warn("[Rankgun] Could not load passes");
         notifyError(player, "Could not load passes", "The server couldn't find the centre's passes");
     }
 }
@@ -63,15 +75,21 @@ function addClientLoader(player: Player) {
     if (clientLoader) clientLoader.Parent = player.FindFirstChild("PlayerGui");
 }
 
-export function Init({ workspaceId, apiToken }: { workspaceId: string, apiToken: string }) {
-    print("[Rankgun] Initialising remote listeners");
+export function Init({ workspaceId, apiToken, verbose }: RankgunInitConfig) {
+    if (verbose) setVerbose(true);
+
+    LogService.Info("[Rankgun] Initialising remote listeners");
 
     BannerNotify.InitServer();
+    Telemetry.init({ workspaceId, apiToken });
 
     // set up remote listeners
-    remotes.getCentreData.onRequest(() => { 
+    remotes.getCentreData.onRequest(() => {
         const rankResults = getRanks(workspaceId, apiToken);
-        if (rankResults.ranks) ranksCache = rankResults.ranks;
+        if (rankResults.ranks) {
+            ranksCache = rankResults.ranks;
+            Telemetry.track("ranks_loaded", { rankCount: rankResults.ranks.size() });
+        }
 
         return rankResults;
     });

--- a/src/server/rankgunApi.ts
+++ b/src/server/rankgunApi.ts
@@ -1,9 +1,31 @@
 import { HttpService } from "@rbxts/services";
 import { RankResults } from "shared/types";
 
+import { Telemetry } from "./telemetry";
+
 const BASE_URL = "https://api.rankgun.works";
 
+let verbose = false;
+
+export function setVerbose(value: boolean) {
+    verbose = value;
+}
+
+/** Report a non-200 response as an api_error event (status + short code only). */
+function reportError(call: string, statusCode: number, body: unknown) {
+    if (statusCode === 200) {
+        return;
+    }
+    Telemetry.track("api_error", {
+        call,
+        httpStatus: statusCode,
+        code: (body as { code?: string }).code,
+    });
+}
+
 function httpRequest(path: string, apiToken: string, method: "GET" | "POST", body?: string) {
+    if (verbose) print(`[Rankgun] → ${method} ${path}${body ? ` ${body}` : ""}`);
+
     const request = HttpService.RequestAsync({
         Url: `${BASE_URL}${path}`,
         Method: method,
@@ -14,11 +36,14 @@ function httpRequest(path: string, apiToken: string, method: "GET" | "POST", bod
     });
 
     if (request.Body) {
+        const decodedBody = HttpService.JSONDecode(request.Body) as object;
+        if (verbose) print(`[Rankgun] ← ${request.StatusCode} ${HttpService.JSONEncode(decodedBody)}`);
         return {
-            Body: HttpService.JSONDecode(request.Body),
+            Body: decodedBody,
             StatusCode: request.StatusCode
         }
     } else {
+        if (verbose) warn(`[Rankgun] ← ${request.StatusCode} (empty body)`);
         return {
             Body: { success: false, code: "API_FAILED", error: "Failed to contact Rankgun API" },
             StatusCode: 500
@@ -28,6 +53,7 @@ function httpRequest(path: string, apiToken: string, method: "GET" | "POST", bod
 
 export function getRanks(workspaceId: string, apiToken: string): RankResults {
     const apiResponse = httpRequest(`/api/ranking-centre?workspaceId=${workspaceId}`, apiToken, "GET");
+    reportError("ranks", apiResponse.StatusCode, apiResponse.Body);
     return apiResponse.Body as RankResults;
 }
 
@@ -40,5 +66,6 @@ export function setRank(player: Player, rank: number, workspaceId: string, apiTo
             workspaceId: workspaceId,
         }),
     );
+    reportError("setrank", apiResponse.StatusCode, apiResponse.Body);
     return apiResponse;
 }

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -1,0 +1,123 @@
+import { HttpService, Players, RunService } from "@rbxts/services";
+
+import { CENTRE_VERSION } from "../version";
+
+/**
+ * Lightweight, fire-and-forget operational telemetry for the ranking centre.
+ *
+ * Because centres are self-hosted, RankGun otherwise has no remote visibility
+ * into whether a centre is running, on what build, or where it's failing. This
+ * module reports aggregate operational events to RankGun's `/api/telemetry`
+ * endpoint using the same `x-api-key` the centre already holds.
+ *
+ * It never sends end-user PII — no UserIds, usernames, gamepass ownership tied
+ * to a user, or raw error bodies. Only instance-level facts and short status/
+ * error codes. All network calls are wrapped in `pcall` and dispatched on a
+ * separate thread, so telemetry can never block or break gameplay.
+ */
+
+const BASE_URL = "https://api.rankgun.works";
+const CENTRE_TYPE = "ranking";
+const FLUSH_INTERVAL = 30; // seconds between batched flushes
+const HEARTBEAT_INTERVAL = 120; // seconds between liveness heartbeats
+const MAX_QUEUE = 20; // flush early once this many events are queued
+
+export type TelemetryProps = {
+	targetRankId?: number;
+	success?: boolean;
+	httpStatus?: number;
+	call?: string;
+	code?: string;
+	rankCount?: number;
+};
+
+type QueuedEvent = { type: string; t: number; props?: TelemetryProps };
+
+let apiToken = "";
+let started = false;
+let startClock = 0;
+let queue: QueuedEvent[] = [];
+
+function environment(): "live" | "studio" {
+	return RunService.IsStudio() ? "studio" : "live";
+}
+
+/** Build the current envelope and send any queued events on a separate thread. */
+function flush() {
+	if (queue.size() === 0) {
+		return;
+	}
+
+	const events = queue;
+	queue = [];
+
+	const payload = {
+		centreType: CENTRE_TYPE,
+		centreVersion: CENTRE_VERSION,
+		placeId: game.PlaceId,
+		universeId: game.GameId,
+		jobId: game.JobId,
+		environment: environment(),
+		playerCount: Players.GetPlayers().size(),
+		uptimeSec: math.floor(os.clock() - startClock),
+		events,
+	};
+
+	task.spawn(() => {
+		pcall(() => {
+			HttpService.RequestAsync({
+				Url: `${BASE_URL}/api/telemetry`,
+				Method: "POST",
+				Headers: {
+					"Content-Type": "application/json",
+					"x-api-key": apiToken,
+				},
+				Body: HttpService.JSONEncode(payload),
+			});
+		});
+	});
+}
+
+/** Queue an event; flushes early once the queue is full. */
+function track(eventType: string, props?: TelemetryProps) {
+	if (!started) {
+		return;
+	}
+
+	queue.push({ type: eventType, t: os.time(), props });
+
+	if (queue.size() >= MAX_QUEUE) {
+		flush();
+	}
+}
+
+/** Start telemetry: emit a boot event and run the flush + heartbeat loops. */
+function init(config: { workspaceId: string; apiToken: string }) {
+	if (started) {
+		return;
+	}
+
+	apiToken = config.apiToken;
+	startClock = os.clock();
+	started = true;
+
+	track("centre_boot");
+	flush();
+
+	task.spawn(() => {
+		while (true) {
+			task.wait(FLUSH_INTERVAL);
+			flush();
+		}
+	});
+
+	task.spawn(() => {
+		while (true) {
+			task.wait(HEARTBEAT_INTERVAL);
+			track("heartbeat");
+			flush();
+		}
+	});
+}
+
+export const Telemetry = { init, track };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -39,3 +39,11 @@ export const tRankResults = t.interface({
     error: t.optional(t.string),
     code: t.optional(t.string),
 })
+
+// init config
+
+export type RankgunInitConfig = {
+    workspaceId: string,
+    apiToken: string,
+    verbose?: boolean
+};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+// The release workflow (.github/workflows/release.yml) overwrites this file with
+// the published release tag before compiling. Local and Studio builds report "dev".
+export const CENTRE_VERSION = "dev";


### PR DESCRIPTION
This pull request introduces operational telemetry to the ranking centre, refactors logging to use `LogService` for consistency, and adds a verbose logging option for easier debugging. The telemetry system reports aggregate, non-PII events to RankGun's API, allowing for better monitoring of self-hosted centres. Additionally, the release workflow now stamps the build version, and documentation has been updated to describe telemetry and configuration options.

**Telemetry and Monitoring Enhancements:**

* Introduced a new `src/server/telemetry.ts` module that reports lightweight, aggregate operational events (such as centre boot, heartbeats, rank attempts, and API errors) to RankGun's `/api/telemetry` endpoint, ensuring no end-user PII is sent and all reporting is non-blocking.
* Integrated telemetry events throughout the ranking flow in `src/server/index.ts` and `src/server/rankgunApi.ts`, including tracking of rank redemption attempts, results, gamepass ownership, API errors, and ranks loaded. [[1]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888R31-R49) [[2]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L50-R68) [[3]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L66-R92) [[4]](diffhunk://#diff-0f7f69c27ce13716059a2b4891341f58eaf2c884a2a4d5fb941d2e97a5a4f4a9R56) [[5]](diffhunk://#diff-0f7f69c27ce13716059a2b4891341f58eaf2c884a2a4d5fb941d2e97a5a4f4a9R69)

**Logging Improvements:**

* Refactored all logging and warnings in both server and client code to use `LogService` methods (`Info`, `Warn`) instead of `print`/`warn` for more consistent and structured output. [[1]](diffhunk://#diff-7c2c257c7c6cdac70e5dbc7bbc6e9b71798cc26828c205aa71a64bc96ca7afb4L4-R4) [[2]](diffhunk://#diff-7c2c257c7c6cdac70e5dbc7bbc6e9b71798cc26828c205aa71a64bc96ca7afb4L41-R41) [[3]](diffhunk://#diff-8c79b85ff3044d9eb4eb3db1eb76a8460b6831fa0c68e802ae8f7fc92446d295R2-R6) [[4]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L1-R8) [[5]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L50-R68)

**Configuration and Release Process:**

* Added a `verbose` option to the `Rankgun.Init` config (documented in `readme.md` and typed in `src/shared/types.ts`) to enable detailed logging of API requests/responses for debugging. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L26-R27) [[2]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17R42-R49) [[3]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L66-R92) [[4]](diffhunk://#diff-0f7f69c27ce13716059a2b4891341f58eaf2c884a2a4d5fb941d2e97a5a4f4a9R4-R28) [[5]](diffhunk://#diff-0f7f69c27ce13716059a2b4891341f58eaf2c884a2a4d5fb941d2e97a5a4f4a9R39-R46)
* Updated the release workflow (`.github/workflows/release.yml`) to stamp the current release version into `src/version.ts`, which is then reported in telemetry. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R31-R33) [[2]](diffhunk://#diff-413a98cce89449386f145428a4a484110952a63844bf514337c56c9d7ea50087R1-R3)

**Documentation:**

* Expanded the `readme.md` with a new section explaining telemetry, its purpose, what data is collected, and privacy assurances.

These changes collectively improve observability, debuggability, and reliability of the ranking centre, while maintaining user privacy.